### PR TITLE
Separate meetup table into each years

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,24 +1,36 @@
-# Meetups of Rust Taiwan Community in 2018
+# Meetups of Rust Taiwan Community
 
-| Session | Date | Chapter | Speaker | Slides |
-|:-------:|:----:|:------- |:------- |:------:|
-| 1 | 2018/6/21 | [1. Getting Started](https://doc.rust-lang.org/book/second-edition/ch01-00-getting-started.html) | @dieter | [link](https://dieterplex.gitlab.io/rust-studygroup/intro&ch1.html)|
-|   |           | [2. Programming a Guessing Game](https://doc.rust-lang.org/book/second-edition/ch02-00-guessing-game-tutorial.html) | @球魚 | [link](https://slides.com/lili668668/rust-ch2/#/)|
-| 2 | 2018/7/21 | [3. Common Programming Concepts](https://doc.rust-lang.org/book/second-edition/ch03-00-common-programming-concepts.htmll) | @tigercosmos | [link](./slides/CH3.pdf)|
-|   |           | [4. Understanding Ownership](https://doc.rust-lang.org/book/second-edition/ch04-00-understanding-ownership.html) | @wayling | [link](https://docs.google.com/presentation/d/1UHW8qxp3nSfNQunpE9tVwJ6yxh7Y3ghNNmttedY1Skw/edit)|
-| 3 | 2018/8/13 | [5. Using Structs to Structure Related Data](https://doc.rust-lang.org/book/second-edition/ch05-00-structs.html) | @kais | [link](https://hackmd.io/p/Skw4Xk_bQ#)|
-|   |           | [6. Enums and Pattern Matching](https://doc.rust-lang.org/book/second-edition/ch06-00-enums.html) | @IU | [link](https://drive.google.com/drive/folders/1s4iX4XXh_pFBvHpR6w2KXHq5uz04NgeO?usp=sharing)|
-| 4 | 2018/9/3 | [7. Modules](https://doc.rust-lang.org/book/second-edition/ch07-00-modules.html) | @dieter | [link](https://dieterplex.gitlab.io/rust-studygroup/ch7.html)|
-|   |          | [8. Common Collections](https://doc.rust-lang.org/book/second-edition/ch08-00-common-collections.html) | @weihanglo | [link](https://weihanglo.tw/slides/rust-collections)|
-| 5 | 2018/10/8 | [9. Error Handling](https://doc.rust-lang.org/book/second-edition/ch09-00-error-handling.html) | @kais | [link](https://hackmd.io/p/B1lPZJ4Pqm#/) |
-|   |          | [10. Generic Types, Traits, and Lifetimes](https://doc.rust-lang.org/book/second-edition/ch10-00-generics.html) | @tigercosmos | [link](https://hackmd.io/p/Hk9fOfvqm#/) |
-| 6 | 2018/11/12 | [11. Testing](https://doc.rust-lang.org/book/second-edition/ch11-00-testing.html) | @kais | [link](https://hackmd.io/p/B186LUraX#/)|
-|   |          | [12. An I/O Project: Building a Command Line Program](https://doc.rust-lang.org/book/second-edition/ch12-00-an-io-project.html) | @tigercosmos | [link](https://hackmd.io/p/r18I6LrTQ#/) |
-| 7 | 2018/12/10 | [13. Functional Language Features: Iterators and Closures](https://doc.rust-lang.org/book/second-edition/ch13-00-functional-features.html) | @球魚 |[link](https://slides.com/lili668668/rust-12#/)|
-|   |          | [14. More about Cargo and Crates.io](https://doc.rust-lang.org/book/second-edition/ch14-00-more-about-cargo.html) | @dieter ||
-| 8 | 2019/01/21 | [15. Smart Pointers](https://doc.rust-lang.org/book/second-edition/ch15-00-smart-pointers.html) | @weihang |[link](https://weihanglo.tw/slides/rust-smart-pointers.html)|
-|   |          | [16. Fearless Concurrency](https://doc.rust-lang.org/book/second-edition/ch16-00-concurrency.html) | @tigercosmos ||
-| 9 |          | [17. Is Rust an Object-Oriented Programming Language?](https://doc.rust-lang.org/book/second-edition/ch17-00-oop.html) | @球魚 ||
-|   |          | [18. Patterns Match the Structure of Values](https://doc.rust-lang.org/book/second-edition/ch18-00-patterns.html) | @sharre ||
-| 10 |          | [19. Advanced Features](https://doc.rust-lang.org/book/second-edition/ch19-00-advanced-features.html) | @weihanglo ||
-|    |          | [20. Final Project: Building a Multithreaded Web Server](https://doc.rust-lang.org/book/second-edition/ch20-00-final-project-a-web-server.html) | @sharre ||
+## Table of Contents
+
+- [2018](#2018)
+- [2019](#2019)
+
+### 2018
+
+| Date | Chapter | Speaker | Slides |
+|:----:|:------- |:------- |:------:|
+| 2018/6/21 | [1. Getting Started](https://doc.rust-lang.org/book/second-edition/ch01-00-getting-started.html) | @dieter | [link](https://dieterplex.gitlab.io/rust-studygroup/intro&ch1.html)|
+|           | [2. Programming a Guessing Game](https://doc.rust-lang.org/book/second-edition/ch02-00-guessing-game-tutorial.html) | @球魚 | [link](https://slides.com/lili668668/rust-ch2/#/)|
+| 2018/7/21 | [3. Common Programming Concepts](https://doc.rust-lang.org/book/second-edition/ch03-00-common-programming-concepts.htmll) | @tigercosmos | [link](./slides/CH3.pdf)|
+|           | [4. Understanding Ownership](https://doc.rust-lang.org/book/second-edition/ch04-00-understanding-ownership.html) | @wayling | [link](https://docs.google.com/presentation/d/1UHW8qxp3nSfNQunpE9tVwJ6yxh7Y3ghNNmttedY1Skw/edit)|
+| 2018/8/13 | [5. Using Structs to Structure Related Data](https://doc.rust-lang.org/book/second-edition/ch05-00-structs.html) | @kais | [link](https://hackmd.io/p/Skw4Xk_bQ#)|
+|           | [6. Enums and Pattern Matching](https://doc.rust-lang.org/book/second-edition/ch06-00-enums.html) | @IU | [link](https://drive.google.com/drive/folders/1s4iX4XXh_pFBvHpR6w2KXHq5uz04NgeO?usp=sharing)|
+| 2018/9/3 | [7. Modules](https://doc.rust-lang.org/book/second-edition/ch07-00-modules.html) | @dieter | [link](https://dieterplex.gitlab.io/rust-studygroup/ch7.html)|
+|          | [8. Common Collections](https://doc.rust-lang.org/book/second-edition/ch08-00-common-collections.html) | @weihanglo | [link](https://weihanglo.tw/slides/rust-collections)|
+| 2018/10/8 | [9. Error Handling](https://doc.rust-lang.org/book/second-edition/ch09-00-error-handling.html) | @kais | [link](https://hackmd.io/p/B1lPZJ4Pqm#/) |
+|          | [10. Generic Types, Traits, and Lifetimes](https://doc.rust-lang.org/book/second-edition/ch10-00-generics.html) | @tigercosmos | [link](https://hackmd.io/p/Hk9fOfvqm#/) |
+| 2018/11/12 | [11. Testing](https://doc.rust-lang.org/book/second-edition/ch11-00-testing.html) | @kais | [link](https://hackmd.io/p/B186LUraX#/)|
+|          | [12. An I/O Project: Building a Command Line Program](https://doc.rust-lang.org/book/second-edition/ch12-00-an-io-project.html) | @tigercosmos | [link](https://hackmd.io/p/r18I6LrTQ#/) |
+| 2018/12/10 | [13. Functional Language Features: Iterators and Closures](https://doc.rust-lang.org/book/second-edition/ch13-00-functional-features.html) | @球魚 |[link](https://slides.com/lili668668/rust-12#/)|
+|          | [14. More about Cargo and Crates.io](https://doc.rust-lang.org/book/second-edition/ch14-00-more-about-cargo.html) | @dieter ||
+
+### 2019
+
+| Date | Chapter | Speaker | Slides |
+|:----:|:------- |:------- |:------:|
+| 2019/01/21 | [15. Smart Pointers](https://doc.rust-lang.org/book/second-edition/ch15-00-smart-pointers.html) | @weihang |[link](https://weihanglo.tw/slides/rust-smart-pointers.html)|
+|          | [16. Fearless Concurrency](https://doc.rust-lang.org/book/second-edition/ch16-00-concurrency.html) | @tigercosmos ||
+|          | [17. Is Rust an Object-Oriented Programming Language?](https://doc.rust-lang.org/book/second-edition/ch17-00-oop.html) | @球魚 ||
+|          | [18. Patterns Match the Structure of Values](https://doc.rust-lang.org/book/second-edition/ch18-00-patterns.html) | @sharre ||
+|          | [19. Advanced Features](https://doc.rust-lang.org/book/second-edition/ch19-00-advanced-features.html) | @weihanglo ||
+|          | [20. Final Project: Building a Multithreaded Web Server](https://doc.rust-lang.org/book/second-edition/ch20-00-final-project-a-web-server.html) | @sharre ||

--- a/dummy.rs
+++ b/dummy.rs
@@ -1,0 +1,4 @@
+// A dummy file to make GitHub recognize this repo as a Rust repo
+fn main() {
+    println!("Taiwan No. 1!");
+}


### PR DESCRIPTION
Once this PR lands, we can rename this repo as `meetup` instead.
Also, I added a dummy file to make GitHub recognize this repo as an Rust repo.